### PR TITLE
Improv  #97007 - Hyphen homoglyph substitution 

### DIFF
--- a/src/cameraLogic/ocr.ts
+++ b/src/cameraLogic/ocr.ts
@@ -237,10 +237,20 @@ export class OCR {
 
   /** Handles the homoglyphing substitution on the word level. */
   private handleHomoglyphing(word: Word): Word {
-    const original = word.text;
-    word.text = Array.from(original)
+    let original = word.text;
+    let alteredOriginal: string | undefined = undefined;
+    let lineTagIdentifier = '';
+
+    if (ocrFilterer.isLineTag(original)) {
+      const i = word.text.indexOf('"');
+      lineTagIdentifier = word.text.substring(0, i);
+      alteredOriginal = word.text.substring(i);
+    }
+
+    word.text = Array.from(alteredOriginal ?? original)
       .map((char) => getHomoglyphSubstitute(char))
       .join('');
+    word.text = lineTagIdentifier + word.text;
     const altered = word.text;
 
     if (original !== word.text) {

--- a/src/const/homoglyph.ts
+++ b/src/const/homoglyph.ts
@@ -28,7 +28,8 @@ const homoglyphPairs: HomoglyphPair[] = [
   { homoglyph: '|', substitution: '1' },
   { homoglyph: '!', substitution: '1' },
   { homoglyph: '?', substitution: '2' },
-  { homoglyph: '>', substitution: '7' }
+  { homoglyph: '>', substitution: '7' },
+  { homoglyph: '.', substitution: '-' }
 ];
 Object.preventExtensions(homoglyphPairs);
 

--- a/src/utils/filtering.ts
+++ b/src/utils/filtering.ts
@@ -29,6 +29,10 @@ interface OCRFilterer {
    * @param {string} exceptions Any characters that should be excempted, for example "()/".
    */
   filterTrailingAndLeadingChars: (word: string, exceptions?: string) => string;
+  /**
+   * Accepts a word and determines if it could be from a line tag sign.
+   */
+  isLineTag: (sequence: string) => boolean;
 }
 
 const ocrFilterer: OCRFilterer = Object.create(null);
@@ -94,6 +98,10 @@ ocrFilterer.isMotorTag = function (word: string) {
   function sequenceMatch(sequence: '(M)' | '(C)') {
     return word.match(/(\(M\))|(\(C\))/g)?.join('') === sequence;
   }
+};
+
+ocrFilterer.isLineTag = function isLineTag(word: string) {
+  return word.substring(0, 5).includes('"');
 };
 
 export { ocrFilterer };


### PR DESCRIPTION
- Any occurences of periods in read tag numbers are changed to hyphens (-) with the exception of the identifying part of line tags.
Fixes #AB97007