### PR TITLE
Improv #107192 - Camera start error handling

### DIFF
--- a/echoModule.config.json
+++ b/echoModule.config.json
@@ -1,6 +1,6 @@
 {
   "bundler": "webpack",
-  "webpackConfigPath": "./webpack/webpack.config.js",
+  "webpackConfigPath": "./webpack.config.js",
   "manifest": {
     "name": "Echo Tag Scanner",
     "key": "echo-tag-scanner",

--- a/src/EchoTagScanner.tsx
+++ b/src/EchoTagScanner.tsx
@@ -1,10 +1,16 @@
-import React, { memo, useEffect, useState } from 'react';
-import { logger } from '@utils';
-import { Viewfinder, Scanner as ScannerUI, ZoomTutorial } from '@ui';
-import { ErrorBoundary } from '@services';
-import { useGetMediastream } from '@hooks';
-import styled from 'styled-components';
-import { zIndexes } from '@const';
+import React, { memo, useEffect, useState } from "react";
+import { logger } from "@utils";
+import {
+  CameraCouldNotBeStartedAlert,
+  Scanner as ScannerUI,
+  StartingCameraLoading,
+  Viewfinder,
+  ZoomTutorial,
+} from "@ui";
+import { ErrorBoundary } from "@services";
+import { useGetMediastream } from "@hooks";
+import styled from "styled-components";
+import { zIndexes } from "@const";
 
 /**
  * This component will handle all of the initial React setup and renders before control is handed to the classes.
@@ -19,7 +25,8 @@ const EchoCamera = () => {
   }, []);
 
   // The camera feed.
-  const mediaStream = useGetMediastream();
+  const { mediaStream, mediaStreamRequestError, requestStatus } =
+    useGetMediastream();
 
   // Represets the camera viewfinder.
   const [viewfinder, setViewfinder] = useState<HTMLVideoElement>();
@@ -29,6 +36,19 @@ const EchoCamera = () => {
 
   // Whatever is inside this area is what will be the OCR target.
   const [scanningArea, setScanningArea] = useState<HTMLElement>();
+
+  if (
+    mediaStreamRequestError instanceof OverconstrainedError ||
+    mediaStreamRequestError instanceof Error && requestStatus === "not allowed"
+  ) {
+    return (
+      <CameraCouldNotBeStartedAlert technicalInfo={mediaStreamRequestError} />
+    );
+  }
+
+  if (requestStatus === "requesting") {
+    return <StartingCameraLoading />;
+  }
 
   // No need to render any kind of UI and long as we're waiting for the media stream.
   // This might be improved in the future by letting the user see some kind of camera shell.

--- a/src/UI/error/CameraCouldNotBeStartedAlert.tsx
+++ b/src/UI/error/CameraCouldNotBeStartedAlert.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
-import styled from 'styled-components';
-import { Button } from '@equinor/eds-core-react';
+import React from "react";
+import styled from "styled-components";
+import { Button } from "@equinor/eds-core-react";
 
 type OverconstrainedAlertProps = {
-  technicalInfo: OverconstrainedError;
+  technicalInfo: Error;
 };
 
-const OverconstrainedAlert = (
-  props: OverconstrainedAlertProps
+const CameraCouldNotBeStartedAlert = (
+  props: OverconstrainedAlertProps,
 ): JSX.Element => {
   props.technicalInfo.toString = function () {
-    return this.constraint + ' , ' + this.message + ' , ' + this.name;
+    if (this instanceof OverconstrainedError) {
+      return this.constraint + " , " + this.message + " , " + this.name;
+    } else {
+      return this.message + " , " + this.name;
+    }
   };
   return (
     <AlertContainer>
@@ -18,19 +22,20 @@ const OverconstrainedAlert = (
         <Section>
           <ErrorHeader>We could not start your camera.</ErrorHeader>
           <p>
-            Unfortunately, an error occured while we tried to start your rear
-            camera. There could be a number of reasons for this:
+            Unfortunately, an error occured while we tried to start your{" "}
+            <u>
+              rear camera
+            </u>. There could be a number of reasons for this:
           </p>
           <ul>
-            <li> Another app or webpage might be using the camera.</li>
-            <li> There might be something wrong with the camera hardware.</li>
+            {getReasons(props.technicalInfo)}
           </ul>
 
           <p>
-            You can test your camera{' '}
+            You can test your camera{" "}
             <a href="https://webcamtests.com" target="_blank" rel="noreferrer">
               here
-            </a>{' '}
+            </a>{" "}
             (opens in a new tab)
           </p>
 
@@ -53,6 +58,37 @@ const OverconstrainedAlert = (
     </AlertContainer>
   );
 };
+
+function getReasons(technicalInfo: Error): JSX.Element | undefined {
+  if (technicalInfo instanceof OverconstrainedError) {
+    return (
+      <>
+        <li>Another app or webpage might be using the camera.</li>
+        <li>There might be something wrong with the camera hardware.</li>
+        <li>
+          There might be a technical constraint to the camera.{" "}
+          <u>Check the Technical info below.</u>
+        </li>
+      </>
+    );
+  } else if (
+    technicalInfo.name === "NotAllowedError"
+  ) {
+    return (
+      <>
+        <li>
+          We do not have permission to use your camera (did you see a prompt
+          that asked for camera access?). Check browser settings to see if the
+          browser is actively blocking camera access.
+        </li>
+        <li>
+          Some browsers can automatically block the camera if the user does not
+          allow access after a period of time.
+        </li>
+      </>
+    );
+  }
+}
 
 const ControlPanel = styled.fieldset`
   display: flex;
@@ -96,4 +132,4 @@ const Section = styled.section`
   margin: 0 var(--medium);
 `;
 
-export { OverconstrainedAlert };
+export { CameraCouldNotBeStartedAlert };

--- a/src/UI/index.ts
+++ b/src/UI/index.ts
@@ -1,27 +1,28 @@
-export { Scanner } from './ScannerUI';
+export { Scanner } from "./ScannerUI";
 
-export { ZoomTutorial } from './notification/ZoomTutorial';
-export { Toast } from './notification/Toast';
-export { NotificationHandler } from './notification/NotificationListener';
-export { TorchButton, ScannerButton } from './cameracontrols/CameraButton';
-export { SearchResults } from './searchresults/SearchResults';
-export { ScanningIndicator } from './progress/ScanningLoading';
-export { OverconstrainedAlert } from './error/OverconstrainedAlert';
+export { ZoomTutorial } from "./notification/ZoomTutorial";
+export { Toast } from "./notification/Toast";
+export { NotificationHandler } from "./notification/NotificationListener";
+export { ScannerButton, TorchButton } from "./cameracontrols/CameraButton";
+export { SearchResults } from "./searchresults/SearchResults";
+export { ScanningIndicator } from "./progress/ScanningLoading";
+export { CameraCouldNotBeStartedAlert } from "./error/CameraCouldNotBeStartedAlert";
+export { StartingCameraLoading } from "./progress/StartingCameraLoading";
 
-export { GestureArea } from './cameracontrols/GestureArea';
-export { CameraControlsRow } from './cameracontrols/CameraControlsRow';
-export { CameraControls } from './cameracontrols/ControlPad';
-export { CloseButton } from './cameracontrols/CloseButton';
+export { GestureArea } from "./cameracontrols/GestureArea";
+export { CameraControlsRow } from "./cameracontrols/CameraControlsRow";
+export { CameraControls } from "./cameracontrols/ControlPad";
+export { CloseButton } from "./cameracontrols/CloseButton";
 
-export { SystemInfoTrigger } from './viewfinder/SystemInfoTrigger';
-export { Viewfinder } from './viewfinder/Viewfinder';
-export { Backdrop } from './viewfinder/Backdrop';
+export { SystemInfoTrigger } from "./viewfinder/SystemInfoTrigger";
+export { Viewfinder } from "./viewfinder/Viewfinder";
+export { Backdrop } from "./viewfinder/Backdrop";
 
-export { DebugInfoOverlay } from './debug/DebugInfoOverlay';
-export { VersionNumber } from './debug/VersionNumber';
-export { CapturePreview } from './debug/CapturePreview';
-export { DeveloperTools } from './debug/DeveloperTools';
+export { DebugInfoOverlay } from "./debug/DebugInfoOverlay";
+export { VersionNumber } from "./debug/VersionNumber";
+export { CapturePreview } from "./debug/CapturePreview";
+export { DeveloperTools } from "./debug/DeveloperTools";
 
-export { Dialogues } from './dialogues/DialogueWrapper';
+export { Dialogues } from "./dialogues/DialogueWrapper";
 
-export { LabelAndClose } from './toolbar/LabelAndClose';
+export { LabelAndClose } from "./toolbar/LabelAndClose";

--- a/src/UI/progress/StartingCameraLoading.tsx
+++ b/src/UI/progress/StartingCameraLoading.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Progress } from "@equinor/eds-core-react";
+import styled from "styled-components";
+
+export const StartingCameraLoading = () => {
+  return (
+    <CameraLoadingContainer>
+      <Progress.Star />
+
+      <span>Starting the scanner.</span>
+    </CameraLoadingContainer>
+  );
+};
+
+const CameraLoadingContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    gap: 1rem;
+`;

--- a/src/UI/viewfinder/Viewfinder.tsx
+++ b/src/UI/viewfinder/Viewfinder.tsx
@@ -1,9 +1,9 @@
-import React, { SetStateAction, Dispatch, useEffect, useState } from 'react';
-import styled from 'styled-components';
-import { isCustomZoomEvent } from '@utils';
-import { zIndexes } from '@const';
-import { ScanningArea } from './ScanningArea';
-import { Backdrop } from '@ui';
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import styled from "styled-components";
+import { isCustomZoomEvent } from "@utils";
+import { zIndexes } from "@const";
+import { ScanningArea } from "./ScanningArea";
+import { Backdrop } from "@ui";
 
 interface ViewfinderProps {
   setCanvasRef: Dispatch<SetStateAction<HTMLCanvasElement | undefined>>;
@@ -30,17 +30,17 @@ type ZoomBehavior = {
 const Viewfinder = (props: ViewfinderProps): JSX.Element => {
   const [zoomBehaviour, setZoomBehaviour] = useState<ZoomBehavior>({
     zoomFactor: 1,
-    translateOffset: 50
+    translateOffset: 50,
   });
 
   useEffect(function mountSimulatedZoomEventListener() {
-    globalThis.addEventListener('camera-zoom', (event) => {
+    globalThis.addEventListener("camera-zoom", (event) => {
       if (isCustomZoomEvent(event)) {
         let offset = 50;
         if (event.detail.zoomFactor !== 1) offset /= event.detail.zoomFactor;
         setZoomBehaviour({
           zoomFactor: event.detail.zoomFactor,
-          translateOffset: offset
+          translateOffset: offset,
         });
       }
     });
@@ -54,6 +54,7 @@ const Viewfinder = (props: ViewfinderProps): JSX.Element => {
         ref={(el: HTMLVideoElement) => props.setVideoRef(el)}
         playsInline // needed for the viewfinder to work in Safari
         autoPlay
+        muted
         disablePictureInPicture
         controls={false}
         zoomFactor={zoomBehaviour.zoomFactor}

--- a/src/cameraLogic/coreCamera.ts
+++ b/src/cameraLogic/coreCamera.ts
@@ -1,18 +1,18 @@
 import {
-  handleError,
-  getOrientation,
-  logger,
+  determineZoomMethod,
   getCameraPreferences,
-  determineZoomMethod
-} from '@utils';
-import { ErrorRegistry } from '@const';
+  getOrientation,
+  handleError,
+  logger,
+} from "@utils";
+import { ErrorRegistry } from "@const";
 import {
-  DeviceInformation,
   CameraProps,
   CameraResolution,
+  DeviceInformation,
   ZoomMethod,
-  ZoomSteps
-} from '@types';
+  ZoomSteps,
+} from "@types";
 
 /**
  * This object is concerned with the core features of a camera.
@@ -23,7 +23,7 @@ class CoreCamera {
   private _videoTrack?: MediaStreamTrack;
   private _videoTrackSettings?: MediaTrackSettings;
   private _capabilities?: MediaTrackCapabilities = undefined;
-  private _currentOrientation: 'portrait' | 'landscape';
+  private _currentOrientation: "portrait" | "landscape";
   private _activeCamera?: string;
   private _zoom: ZoomSteps;
 
@@ -57,7 +57,7 @@ class CoreCamera {
     this._baseResolution = {
       width: this._viewfinder.width,
       height: this._viewfinder.height,
-      zoomFactor: 1
+      zoomFactor: 1,
     };
     this._deviceInformation = props.deviceInformation;
     this._zoomMethod = determineZoomMethod.call(this);
@@ -149,24 +149,7 @@ class CoreCamera {
   static async getMediastream(): Promise<MediaStream> {
     const cameraPreferences = getCameraPreferences();
     return await navigator.mediaDevices
-      .getUserMedia(cameraPreferences)
-      .catch((error) => {
-        if (error instanceof OverconstrainedError) {
-          if (error.constraint === 'width' || error.constraint === 'height') {
-            handleResolutionOverconstrain(error);
-          }
-        }
-        throw error;
-      });
-
-    function handleResolutionOverconstrain(error: OverconstrainedError) {
-      console.warn(
-        `The camera property ${error?.constraint} is overconstrained.`
-      );
-      console.warn(
-        'This error is being gracefully handled. Operation of camera should continue as normal, but with a lower resolution.'
-      );
-    }
+      .getUserMedia(cameraPreferences);
   }
 
   protected torch(toggled: boolean): void {
@@ -175,13 +158,13 @@ class CoreCamera {
         ?.applyConstraints({ advanced: [{ torch: toggled }] })
         .catch(onTorchRejection);
     } else {
-      logger.log('QA', () => console.warn('Device does not support the torch'));
+      logger.log("QA", () => console.warn("Device does not support the torch"));
     }
 
     function onTorchRejection(reason: unknown) {
       throw handleError(
         ErrorRegistry.torchError,
-        new Error('The torch could not be toggled, more info: ' + reason)
+        new Error("The torch could not be toggled, more info: " + reason),
       );
     }
   }

--- a/src/hooks/useGetMediastream.ts
+++ b/src/hooks/useGetMediastream.ts
@@ -25,9 +25,12 @@ export function useGetMediastream(): Payload {
       const mediaStream = await TagScanner.getMediastream();
       setStream(mediaStream);
       setRequestStatus("allowed");
-    } catch (error) {
-      setError(error as Error);
-      setRequestStatus("not allowed");
+    } catch (cameraRequestError) {
+      if (cameraRequestError instanceof Error) {
+        setError(cameraRequestError);
+        setRequestStatus("not allowed");
+        logger.trackError(cameraRequestError);
+      }
     }
   }, []);
   return { mediaStream, mediaStreamRequestError, requestStatus };

--- a/src/hooks/useGetMediastream.ts
+++ b/src/hooks/useGetMediastream.ts
@@ -1,29 +1,34 @@
-import { useState } from 'react';
-import { TagScanner } from '@cameraLogic';
-import EchoUtils from '@equinor/echo-utils';
-import { logger } from '@utils';
+import { useState } from "react";
+import { TagScanner } from "@cameraLogic";
+import EchoUtils from "@equinor/echo-utils";
+import { logger } from "@utils";
 
-export function useGetMediastream(): MediaStream | undefined {
-  const [stream, setStream] = useState<MediaStream | undefined>();
+type RequestStatus = "requesting" | "not allowed" | "allowed";
+
+type Payload = {
+  mediaStream?: MediaStream;
+  mediaStreamRequestError?: Error;
+  requestStatus: RequestStatus;
+};
+
+export function useGetMediastream(): Payload {
+  const [mediaStream, setStream] = useState<MediaStream | undefined>();
+  const [mediaStreamRequestError, setError] = useState<
+    Error | undefined
+  >();
+  const [requestStatus, setRequestStatus] = useState<RequestStatus>(
+    "requesting",
+  );
 
   EchoUtils.Hooks.useEffectAsync(async () => {
     try {
       const mediaStream = await TagScanner.getMediastream();
       setStream(mediaStream);
+      setRequestStatus("allowed");
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'NotAllowedError') {
-        logger.log('QA', () => {
-          console.error('We do not have access to your camera.');
-          console.error(
-            'Check your browser settings that ' +
-              globalThis.location.href +
-              ' is not blacklisted and that you are running with HTTPS.'
-          );
-        });
-      } else if (error instanceof Error) {
-        throw new Error(error.toString());
-      }
+      setError(error as Error);
+      setRequestStatus("not allowed");
     }
   }, []);
-  return stream;
+  return { mediaStream, mediaStreamRequestError, requestStatus };
 }

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,20 +1,20 @@
-import { Camera, CoreCamera } from '@cameraLogic';
+import { Camera, CoreCamera } from "@cameraLogic";
 import {
   getNotificationDispatcher as dispatchNotification,
-  isLocalDevelopment
-} from '@utils';
-import { ZoomMethod } from '@types';
-import { fixedCameraSettingsRequest } from '@const';
+  isLocalDevelopment,
+} from "@utils";
+import { ZoomMethod } from "@types";
+import { fixedCameraSettingsRequest } from "@const";
 
 function assignZoomSettings(
-  type: 'min' | 'max' | 'step' | 'value',
-  camera: Camera
+  type: "min" | "max" | "step" | "value",
+  camera: Camera,
 ): string {
-  if (type === 'value') {
+  if (type === "value") {
     if (camera.videoTrackSettings?.zoom) {
       return String(camera.videoTrackSettings.zoom);
     } else {
-      return '1';
+      return "1";
     }
   }
   if (camera.capabilities?.zoom) {
@@ -24,7 +24,7 @@ function assignZoomSettings(
   }
   // If zoom capabilities does not exist, we need to return a stringified zero
   // to prevent a stringified undefined to be assigned to the zoom slider.
-  return '0';
+  return "0";
 }
 
 /**
@@ -37,7 +37,7 @@ function getTorchToggleProvider(camera: Camera) {
     };
 
     const onToggleUnsupportedTorch = () => {
-      dispatchNotification('The torch is not supported on this device.')();
+      dispatchNotification("The torch is not supported on this device.")();
     };
 
     if (camera.capabilities?.torch) {
@@ -52,105 +52,54 @@ function determineZoomMethod(this: CoreCamera): ZoomMethod {
   // Device has native support.
   if (this.capabilities?.zoom) {
     // Ensure the max zoom is not above 3.
-    const maxZoom =
-      this.capabilities?.zoom.max > 3 ? 3 : this.capabilities?.zoom.max;
+    const maxZoom = this.capabilities?.zoom.max > 3
+      ? 3
+      : this.capabilities?.zoom.max;
     return {
-      type: 'native',
+      type: "native",
       min: 1,
-      max: maxZoom
+      max: maxZoom,
     } as ZoomMethod;
 
     // Device does not have native support, fall back to simulated zoom.
   } else {
     return {
-      type: 'simulated',
+      type: "simulated",
       min: 1,
-      max: 2
+      max: 2,
     } as ZoomMethod;
   }
 }
 
 function getCameraPreferences(): MediaStreamConstraints {
   const cameraSettingsRequest = {
-    ...fixedCameraSettingsRequest
+    ...fixedCameraSettingsRequest,
   };
-
-  // Developer enviroment on desktop. maxTouchPoints can be 1 with touch emulation.
-  if (isLocalDevelopment && navigator.maxTouchPoints <= 1) {
-    console.info('Creating dev camera request');
-    let overrideWidthDev = cameraSettingsRequest.width.exact;
-    let overrideHeightDev = cameraSettingsRequest.height.exact;
-
-    const cameraId =
-      '883c79d936715fb3d0f70390c627a7bcb9ff395f6835fdf2b068373a35764ec2';
-
-    const request = {
-      video: {
-        width: { exact: overrideWidthDev },
-        height: {
-          exact: overrideHeightDev
-        },
-
-        // Higher FPS is good for a scanning operation.
-        frameRate: { ideal: cameraSettingsRequest.fps?.ideal },
-
-        deviceId: {
-          exact: cameraId
-        }
-      },
-      audio: false
-    } as MediaStreamConstraints;
-
-    return request;
-  }
-
-  // Developer environment on a mobile device.
-  if (isLocalDevelopment && navigator.maxTouchPoints > 1) {
-    console.info('Creating mobile dev capture request.');
-    let overrideWidthDev = cameraSettingsRequest.width.exact;
-    let overrideHeightDev = cameraSettingsRequest.height.exact;
-
-    return {
-      video: {
-        width: { exact: overrideWidthDev },
-        height: {
-          exact: overrideHeightDev
-        },
-
-        // Higher FPS is good for a scanning operation.
-        frameRate: { ideal: cameraSettingsRequest.fps?.ideal },
-
-        // Ensures the rear-facing camera is used.
-        facingMode: { exact: 'environment' }
-      },
-      audio: false
-    } as MediaStreamConstraints;
-  }
 
   // This is the default preferences, which is also used in production.
   return {
     video: {
       width: {
-        exact: cameraSettingsRequest.width.exact
+        exact: cameraSettingsRequest.width.exact,
       },
       height: {
-        exact: cameraSettingsRequest.height.exact
+        exact: cameraSettingsRequest.height.exact,
       },
 
       // Higher FPS is good for a scanning operation.
       frameRate: {
-        ideal: cameraSettingsRequest.fps?.ideal
+        ideal: cameraSettingsRequest.fps?.ideal,
       },
 
-      facingMode: { exact: 'environment' }
+      facingMode: { ideal: "environment" },
     },
-    audio: false
+    audio: false,
   } as MediaStreamConstraints;
 }
 
 export {
   assignZoomSettings,
-  getTorchToggleProvider,
   determineZoomMethod,
-  getCameraPreferences
+  getCameraPreferences,
+  getTorchToggleProvider,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require("path");
+const webpack = require("webpack");
+
+// Note: does not include a trailing slash.
+const rootPath = path.resolve(__dirname);
+
+/**
+ * Refer to the documentation below in order to do your webpack overrides.
+ * Override rules:
+ * -> Objects are (deeply) merged.
+ * -> Strings are overridden.
+ * -> Arrays are concatenated.
+ * https://webpack.js.org/configuration/
+ */
+module.exports = {
+  resolve: {
+    alias: {
+      "@hooks": path.join(rootPath, "/src/hooks/"),
+      "@types": path.join(rootPath, "/src/types/"),
+      "@services": path.join(rootPath, "/src/services/"),
+      "@utils": path.join(rootPath, "/src/utils/"),
+      "@cameraLogic": path.join(rootPath, "/src/cameraLogic/"),
+      "@ui": path.join(rootPath, "/src/UI/"),
+      "@const": path.join(rootPath, "/src/const/"),
+    },
+  },
+  devServer: {
+    headers: {
+      "permissions-policy": "camera=self",
+    },
+  },
+  experiments: {
+    topLevelAwait: true,
+  },
+};


### PR DESCRIPTION
This PR adds some refined error handling for cases when the camera could not be started. The catch reasons that are handled are when the camera is denied access in browser settings and when the requested camera features cannot be met by the camera hardware.
In addition, it adds a loading indicator for when the camera is being requested.

**Camera is loading.**
![image](https://user-images.githubusercontent.com/10920843/232033292-82657c0d-16b3-4376-a073-7b2d71c458d3.png)

**Camera has errored out because of denied permissions**
![image](https://user-images.githubusercontent.com/10920843/232033461-aa7fb920-2b78-4330-805c-16e10aeaa5f9.png)
