### PR TITLE
Improv #107192 - Autoplay error handling

### DIFF
--- a/src/cameraLogic/camera.ts
+++ b/src/cameraLogic/camera.ts
@@ -14,11 +14,11 @@ import {
   handleError,
   dispatchCameraResolutionEvent,
   dispatchZoomEvent,
-  defineOrientationChangeEvent
+  defineOrientationChangeEvent,
 } from '@utils';
 import { CoreCamera } from './coreCamera';
 import { Postprocessor } from './postprocessor';
-import { ErrorRegistry } from '../const';
+import { ErrorRegistry } from '@const';
 
 /**
  * This object acts as a proxy towards CoreCamera.
@@ -40,6 +40,13 @@ class Camera extends Postprocessor {
       this.videoTrack.addEventListener('ended', this.refreshStream.bind(this));
     }
     this._orientationChangeHandler = defineOrientationChangeEvent.call(this);
+    this.viewfinder.addEventListener("play", () => {
+      if(this.viewfinder.paused && !this.viewfinder.autoplay) {
+        const error = new Error("The camera could not be started.", {cause: "The viewfinder video element did not accept autoplaying."});
+        logger.trackError(error);
+        handleError(ErrorRegistry.autoplayFailed, error);
+      }
+    }, {once: true})
 
     // For debugging purposes.
     MediaStreamTrack.prototype.toString = reportVideoTrack;

--- a/src/const/Error.ts
+++ b/src/const/Error.ts
@@ -10,6 +10,7 @@ export interface IErrorRegistry {
   zoomError: ErrorRecord;
   torchError: ErrorRecord;
   overconstrainedError: ErrorRecord;
+  autoplayFailed: ErrorRecord;
 }
 
 export enum ErrorKey {
@@ -60,5 +61,10 @@ export const ErrorRegistry: IErrorRegistry = {
     key: ErrorKey.EchoCameraRuntimeErrors,
     severity: 'high',
     userMessage: ErrorMessages.OverconstrainedError
+  },
+  autoplayFailed: {
+    key: ErrorKey.EchoCameraRuntimeErrors,
+    severity: "high",
+    userMessage: "The web browser did not allow us to autoplay the viewfinder."
   }
 } as const;

--- a/src/services/errorBoundary/ErrorBoundary.tsx
+++ b/src/services/errorBoundary/ErrorBoundary.tsx
@@ -31,7 +31,8 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, unknown> {
     severity: undefined
   };
 
-  private listenerCleanup?: () => void;
+  private apiErrorListener?: () => void;
+  private runtimeErrorListener?: () => void;
 
   componentDidCatch(error: unknown, info: unknown): void {
     if (error instanceof Error) {
@@ -45,16 +46,18 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, unknown> {
   }
 
   componentDidMount(): void {
-    this.listenerCleanup = eventHub.subscribe(
+    this.apiErrorListener = eventHub.subscribe(
       ErrorKey.EchoCameraApiError,
       (error: EchoCameraError) => this.errorListener(error)
     );
+    this.runtimeErrorListener = eventHub.subscribe(ErrorKey.EchoCameraRuntimeErrors, (error: EchoCameraError) => this.errorListener(error))
   }
 
   componentWillUnmount(): void {
-    if (this.listenerCleanup) {
-      this.listenerCleanup();
-    }
+    if (this.apiErrorListener)
+      this.apiErrorListener();
+    if (this.runtimeErrorListener) this.runtimeErrorListener();
+    
   }
 
   private getInnerError(error: BaseError) {

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -90,7 +90,7 @@ function getCameraPreferences(): MediaStreamConstraints {
         ideal: cameraSettingsRequest.fps?.ideal,
       },
 
-      facingMode: { ideal: "environment" },
+      facingMode: { exact: "environment" },
     },
     audio: false,
   } as MediaStreamConstraints;

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,7 +1,6 @@
 import { Camera, CoreCamera } from "@cameraLogic";
 import {
   getNotificationDispatcher as dispatchNotification,
-  isLocalDevelopment,
 } from "@utils";
 import { ZoomMethod } from "@types";
 import { fixedCameraSettingsRequest } from "@const";


### PR DESCRIPTION
If the user agent refuses to autoplay the viewfinder for some reason, an event listener will log the error and summon ErrorBoundary.