### PR TITLE
chore #160190 - Major version bump after react 19 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-camera-web",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-camera-web",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "license": "MIT",
             "devDependencies": {
                 "@equinor/echo-base": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-camera-web",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "private": false,
     "main": "build/index.js",
     "source": "src/index.ts",


### PR DESCRIPTION
Follow up PR for: https://github.com/equinor/echo-tag-scanner/pull/121

Forgot to update tag scanner version number. Doing it in this PR.

Shouldn't affect the deployed app in any way, this is just an administrative change.